### PR TITLE
Fix a type error and a add a test for firebase.deploy

### DIFF
--- a/ng-deploy/src/builders/actions/__tests__/deploy.spec.ts
+++ b/ng-deploy/src/builders/actions/__tests__/deploy.spec.ts
@@ -42,9 +42,7 @@ describe('Deploy Angular apps', () => {
     await deploy(firebaseMock, context, 'host');
     expect(spy).toHaveBeenCalled();
     expect(spy).toHaveBeenCalledWith({
-      target: 'build',
-      configuration: 'production',
-      project: 'foo'
+      cwd: 'host',
     });
   });
 });

--- a/ng-deploy/src/builders/actions/deploy.ts
+++ b/ng-deploy/src/builders/actions/deploy.ts
@@ -1,10 +1,7 @@
 import { BuilderContext } from '@angular-devkit/architect/src/index2';
-import { virtualFs, experimental, normalize } from '@angular-devkit/core';
-import { Stats } from '@angular-devkit/core/src/virtual-fs/host';
-import { join } from 'path';
 import { FirebaseTools } from '../../ng-deploy/types';
 
-export default async function deploy(firebaseTools: FirebaseTools, context: BuilderContext, host: virtualFs.Host<Stats>,) {
+export default async function deploy(firebaseTools: FirebaseTools, context: BuilderContext, projectRoot: string) {
   try {
     await firebaseTools.list();
   } catch (e) {
@@ -23,13 +20,8 @@ export default async function deploy(firebaseTools: FirebaseTools, context: Buil
     throw new Error('Cannot execute the build target');
   }
 
-  const root = normalize(context.workspaceRoot);
-  const workspace = new experimental.workspace.Workspace(root, host)
-  await workspace.loadWorkspaceFromHost(normalize('angular.json')).toPromise();
-  const project = workspace.getProject(context.target.project)
-
   try {
-    const success = await firebaseTools.deploy({ cwd: join(context.workspaceRoot, project.root) });
+    const success = await firebaseTools.deploy({ cwd: projectRoot });
     context.logger.info(`🚀 Your application is now available at https://${success.hosting.split('/')[1]}.firebaseapp.com/`);
   } catch (e) {
     context.logger.error(e);

--- a/ng-deploy/src/builders/builder.ts
+++ b/ng-deploy/src/builders/builder.ts
@@ -2,13 +2,21 @@ import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/ar
 import { NodeJsSyncHost } from '@angular-devkit/core/node';
 // import { Schema as DeploySchema } from './schema';
 import deploy from './actions/deploy';
+import { normalize, experimental, join } from '@angular-devkit/core';
 
 // Call the createBuilder() function to create a builder. This mirrors
 // createJobHandler() but add typings specific to Architect Builders.
 export default createBuilder<any>(
-  (_: any, context: BuilderContext): Promise<BuilderOutput> => {
+  async (_: any, context: BuilderContext): Promise<BuilderOutput> => {
     // TODO: handle failure
     // The project root is added to a BuilderContext.
-    return deploy(require('firebase-tools'), context, new NodeJsSyncHost()).then(() => ({ success: true }));
+    const root = normalize(context.workspaceRoot);
+    const workspace = new experimental.workspace.Workspace(root, new NodeJsSyncHost())
+    await workspace.loadWorkspaceFromHost(normalize('angular.json')).toPromise();
+    if (!context.target) {
+      throw new Error('Cannot deploy the application without a target');
+    }
+    const project = workspace.getProject(context.target.project)
+    return deploy(require('firebase-tools'), context, join(workspace.root, project.root)).then(() => ({ success: true }));
   }
 );

--- a/ng-deploy/src/ng-deploy/index.ts
+++ b/ng-deploy/src/ng-deploy/index.ts
@@ -108,7 +108,7 @@ export function ngDeploy(options: DeployOptions): Rule {
           overwriteIfExists(host, join(normalize(root), '.firebaserc'), stringify(firebaserc(project)));
           return host;
         });
-      })
+      }) as Promise<Tree>
     );
   };
 }

--- a/ng-deploy/src/ng-deploy/index.ts
+++ b/ng-deploy/src/ng-deploy/index.ts
@@ -101,14 +101,14 @@ export function ngDeploy(options: DeployOptions): Rule {
 
     host.overwrite(workspacePath, JSON.stringify(workspace, null, 2));
 
-    return from<Tree>(
+    return from<Promise<Tree>>(
       listProjects().then((projects: Project[]) => {
         return projectPrompt(projects).then(({ project }: any) => {
           overwriteIfExists(host, join(normalize(root), 'firebase.json'), stringify(firebaseJson(root, outputPath)));
           overwriteIfExists(host, join(normalize(root), '.firebaserc'), stringify(firebaserc(project)));
           return host;
         });
-      }) as Promise<Tree>
+      })
     );
   };
 }

--- a/ng-deploy/tsconfig.json
+++ b/ng-deploy/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": "tsconfig",
-    "lib": ["es2018", "dom"],
+    "lib": ["es2018", "es2015", "dom"],
     "declaration": true,
     "module": "commonjs",
     "moduleResolution": "node",


### PR DESCRIPTION
`from` was expecting a more specific type parameter otherwise it was throwing.

In addition, there's one extra test for `firebase.deploy`. Now since the builder passes the path to the project which is used in `cwd` for `firebase.deploy`, I was able to drop one mock.